### PR TITLE
libmakepkg/tidy/upx.sh.in: Fix mime-type for windows applications.

### DIFF
--- a/scripts/libmakepkg/tidy/upx.sh.in
+++ b/scripts/libmakepkg/tidy/upx.sh.in
@@ -35,7 +35,7 @@ tidy_upx() {
 		msg2 "$(gettext "Compressing binaries with %s...")" "UPX"
 		local binary
 		find . -type f -perm -u+w 2>/dev/null | while read -r binary ; do
-			if [[ $(file --brief --mime-type "$binary") = 'application/x-executable' ]]; then
+			if [[ $(file --brief --mime-type "$binary") = 'application/x-dosexec' ]]; then
 				upx "${UPXFLAGS[@]}" "$binary" &>/dev/null ||
 						warning "$(gettext "Could not compress binary : %s")" "${binary/$pkgdir\//}"
 			fi


### PR DESCRIPTION
application/x-executable is mime type for Linux executable files.
For windows, we should use application/x-dosexec.