### PR TITLE
makepkg: Changes for $pkgdir and $pkgdirbase

### DIFF
--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -2825,6 +2825,11 @@ run_split_packaging() {
 	local pkgname_backup=${pkgname[@]}
 	for pkgname in ${pkgname_backup[@]}; do
 		pkgdir="$pkgdirbase/$pkgname"
+		# clean existing pkg directory
+		if [[ -d $pkgdir ]]; then
+			msg "$(gettext "Removing existing %s directory...")" "\$pkgdir/"
+			rm -rf "$pkgdir"
+		fi
 		mkdir "$pkgdir"
 		backup_package_variables
 		run_package $pkgname
@@ -3368,22 +3373,16 @@ else
 		msg "$(gettext "Package directory is ready.")"
 		exit 0
 	fi
-	
-	# clean existing pkg directory
-	# .. changed for MSYS2 to allow pkg itself to be kept
-	# and only have its contents removed (so a symlink to
-	# a spacious drive can be used).
-	if [[ -d $pkgdirbase ]]; then
-		msg "$(gettext "Removing existing %s directory...")" "\$pkgdir/"
-		rm -rf "$pkgdirbase"/*
-	else
-		mkdir -p "$pkgdirbase"
-		chmod a-srwx "$pkgdirbase"
-	fi
-	
+	mkdir -p "$pkgdirbase"
+	chmod a-srwx "$pkgdirbase"
 	chmod 755 "$pkgdirbase"
 	if (( ! SPLITPKG )); then
 		pkgdir="$pkgdirbase/$pkgname"
+		# clean existing pkg directory
+		if [[ -d $pkgdir ]]; then
+			msg "$(gettext "Removing existing %s directory...")" "\$pkgdir/"
+			rm -rf "$pkgdir"
+		fi
 		mkdir "$pkgdir"
 		if (( PKGFUNC )); then
 			run_package

--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -3191,9 +3191,6 @@ else
 
 fi
 
-# set pkgdir to something "sensible" for (not recommended) use during build()
-pkgdir="$pkgdirbase/$pkgbase"
-
 if (( GENINTEG )); then
 	mkdir -p "$srcdir"
 	chmod a-s "$srcdir"

--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -3355,6 +3355,20 @@ if (( NOBUILD )); then
 	msg "$(gettext "Sources are ready.")"
 	exit 0 #E_OK
 else
+	cd_safe "$startdir"
+
+	if (( ! REPKG )); then
+		(( BUILDFUNC )) && run_build
+		(( CHECKFUNC )) && run_check
+		cd_safe "$startdir"
+	fi
+
+	# if inhibiting archive creation, go no further
+	if (( NOARCHIVE )); then
+		msg "$(gettext "Package directory is ready.")"
+		exit 0
+	fi
+	
 	# clean existing pkg directory
 	# .. changed for MSYS2 to allow pkg itself to be kept
 	# and only have its contents removed (so a symlink to
@@ -3366,23 +3380,7 @@ else
 		mkdir -p "$pkgdirbase"
 		chmod a-srwx "$pkgdirbase"
 	fi
-	cd_safe "$startdir"
-
-	if (( ! REPKG )); then
-		if (( ! ( SPLITPKG || PKGFUNC ) )); then
-			chmod 755 "$pkgdirbase"
-			mkdir -p "$pkgdir"
-		fi
-		(( BUILDFUNC )) && run_build
-		(( CHECKFUNC )) && run_check
-		cd_safe "$startdir"
-	fi
-
-	# if inhibiting archive creation, go no further
-	if (( NOARCHIVE )); then
-		msg "$(gettext "Package directory is ready.")"
-		exit 0
-	fi
+	
 	chmod 755 "$pkgdirbase"
 	if (( ! SPLITPKG )); then
 		pkgdir="$pkgdirbase/$pkgname"


### PR DESCRIPTION
This set of patches changes `makepkg`'s behavior so that `$pkgdirbase` is not deleted before `build()`. Instead, only relevant `$pkgdir`'s are deleted just before `package()` is run. The "symlink to a spacious drive" change is no longer needed thanks to this.

The main goal is to work around the issue with `makepkg-mingw`. Its second run (for `mingw32`) currently deletes `$pkgdir` of the first run (for `mingw64`), which is both unexpected and annoying.

I suppose one or two `PKGBUILD`'s will break because of `$pkgdir` is not available in `build()`, but they need to be fixed anyway.

The change has not been tested yet, but if you are willing to accept this change, I will test it for you.