### PR TITLE
fix: duplicated progress bar on windows terminals

### DIFF
--- a/src/pacman/callback.c
+++ b/src/pacman/callback.c
@@ -98,8 +98,11 @@ static int64_t get_update_timediff(int first_call)
 static void fill_progress(const int bar_percent, const int disp_percent,
 		const int proglen)
 {
-	/* 8 = 1 space + 1 [ + 1 ] + 5 for percent */
-	const int hashlen = proglen - 8;
+	/* 9 = 1 space + 1 [ + 1 ] + 5 for percent + 1 blank
+	 * Without the single blank at the end, carriage return wouldn't
+	 * work properly on most windows terminals.
+	 */
+	const int hashlen = proglen - 9;
 	const int hash = bar_percent * hashlen / 100;
 	static int lasthash = 0, mouth = 0;
 	int i;


### PR DESCRIPTION
This fixes the progress bar on non-MinTTY terminals like consolez or the default CMD.exe
Without this, the progress bar is duplicated in a new line on every update.

This happens because carriage return in the windows terminal no longer works once a line is completely filled.

This fix works by simply not filling the line containing the progressbar completely.