### PR TITLE
build_references.sh: Check for Windows-style MSYS2 root path.

### DIFF
--- a/scripts/libmakepkg/lint_package/build_references.sh.in
+++ b/scripts/libmakepkg/lint_package/build_references.sh.in
@@ -35,4 +35,12 @@ warn_build_references() {
 	if find "${pkgdir}" -type f -print0 | xargs -0 grep -q -I "${pkgdirbase}" ; then
 		warning "$(gettext "Package contains reference to %s")" "\$pkgdir"
 	fi
+
+	# Check for Windows-style MSYS2 root path
+	if find "${pkgdir}" -type f -print0 | xargs -0 grep -iFqI "$(cygpath -m /)" ; then
+		warning "$(gettext "Package contains reference to %s")" "\$(cygpath -m /)"
+	fi
+	if find "${pkgdir}" -type f -print0 | xargs -0 grep -iFqI "$(cygpath -w /)" ; then
+		warning "$(gettext "Package contains reference to %s")" "\$(cygpath -w /)"
+	fi
 }


### PR DESCRIPTION
This helps address issue #16 by printing a warning if `$(cygpath -m /)` or `$(cygpath -m \)` is found in the package.  The warning looks like this:

![image](https://cloud.githubusercontent.com/assets/466764/10412593/402bb940-6f3f-11e5-9630-9578ad21e0d8.png)

I generated that warning by trying to build the following test PKGBUILD:

``` .sh
_realname=testpkg
pkgbase=mingw-w64-${_realname}
pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
pkgver=1.0.0
pkgrel=1
pkgdesc='Test package'
arch=('any')
url='http://www.example.com/'
license=('custom')
makedepends=(
  "${MINGW_PACKAGE_PREFIX}-gcc"
)
depends=()
options=()
source=()

sha256sums=()

prepare() {
  mkdir -p "${srcdir}/${_realname}-${pkgver}"
}

build() {
  mkdir -p "${srcdir}/build-${MINGW_CHOST}"
  cd "${srcdir}/build-${MINGW_CHOST}"

  {
    echo "#!/usr/bin/bash"
    echo "cd \"$(cygpath -m /)\""
    echo "pwd"
    echo "cd \"$(cygpath -w /)\""
    echo "pwd"
  } > testpkg
}

check() {
  cd "${srcdir}/build-${MINGW_CHOST}"
}

package() {
  cd "${srcdir}/build-${MINGW_CHOST}"

  install -Dm644 testpkg "${pkgdir}${MINGW_PREFIX}/bin/testpkg"
}
```
