### PR TITLE
update-core: If we are updating core packages, set PS1 and

### DIFF
--- a/scripts/update-core.sh.in
+++ b/scripts/update-core.sh.in
@@ -95,6 +95,8 @@ else
   warning "When the update has completed, you MUST close this MSYS2 window"
   warning "(use Alt-F4 or red [ X ], etc.), rather than 'exit'!!!"
   read -p "Press [Enter] key when ready to start update..."
+  export PS1='Please close this window.'
+  export PROMPT_COMMAND=
   msg "Updating core packages..."
   if ! run_pacman -S --noconfirm --needed ${CRITICAL_PACKAGES} ${OPTIONAL_PACKAGES}; then
     error "$(gettext "'%s' failed to update core packages.")" "$PACMAN"


### PR DESCRIPTION
I did some experiments on fresh installations of MSYS2 in order to figure out the best way to solve this problem:

https://github.com/Alexpux/MSYS2-packages/issues/373

It looks like we need to do two things: change PS1 (and probably PROMPT_COMMAND) in the update-core script itself, and also change update-core so that it gets run inside the user's shell.  This patch does the first part.

The second part is easy and I can make a pull request for it later.  Basically we would just add these lines to /etc/profile:

~~~~
update-core() {
  source /usr/bin/update-core
}
~~~~