### PR TITLE
Added an infinite loop after updating packages.

### DIFF
--- a/scripts/update-core.sh.in
+++ b/scripts/update-core.sh.in
@@ -102,6 +102,10 @@ else
     error "$(gettext "'%s' failed to update core packages.")" "$PACMAN"
     exit 1 # TODO: error code
   fi
+  while :
+  do
+    read -p  "Please close this window."
+  done
 fi
 
 # vim: set noet:


### PR DESCRIPTION
This prevents control from returning to the parent shell, which might in turn try to execute commands found inside PS1 and PROMPT_COMMAND.

My tests showed that adding this loop is sufficient to stop issues like https://github.com/Alexpux/MSYS2-packages/issues/373.  Commit 3f3ecb30bcf104ee950a1d844bc1a77587acf798 (which sets PS1 and PROMPT_COMMAND to safe values) might not even be necessary any more if we add this infinite loop, but it's good to keep that just in case.  To test this loop, I opened a fresh copy of msys64 (extracted from the .tar.xz file), added my loop to /usr/bin/update-core, ran update-core, then closed the window, and everything was fine even though my PS1 had shell commands in it.

One annoying thing is that when I click on the "X" to close the Window after updating packages, MinTTY detects that update-core is still running and it shows a message box to ask if I really want to quit.  That is unfortunate but I hope that our users are smart enough to click "OK".

This is cleaner than turning update-core into a shell function, because doing it that way puts environment variables like TEXTDOMAIN and shell functions like msg into the scope of the user's current shell even if no packages are updated.  (I tested this claim to verify it is true.)

Sorry for making 3 pull requests instead of thinking ahead a little bit and just making one.