### PR TITLE
Allow non-interactive usage for update-core

### DIFF
--- a/scripts/update-core.sh.in
+++ b/scripts/update-core.sh.in
@@ -34,8 +34,9 @@ m4_include(library/utils_fixed_path.sh)
 
 # print usage instructions
 usage() {
-	printf "update-core (pacman) %s\n" ${myver}
-	echo
+  local cmd="${0##*/}"
+  printf "${cmd} (pacman) ${myver}\n\n"
+  printf 'usage: update-core [--noconfirm]\n\n'
 }
 
 version() {
@@ -79,6 +80,14 @@ PACMAN=${PACMAN:-pacman}
 # save full path to command as PATH may change when sourcing /etc/profile
 PACMAN_PATH=$(type -P $PACMAN)
 
+# non-interactive usage
+for argument in "${@}"; do
+  if [[ "${argument}" = --noconfirm ]]; then
+    noconfirm='yes'
+    break
+  fi
+done
+
 msg "Update package databases..."
 if ! run_pacman -Sy; then
   error "$(gettext "'%s' failed to update package databases.")" "$PACMAN"
@@ -94,7 +103,7 @@ else
   msg "windows, Bash sessions, etc) before proceeding."
   warning "When the update has completed, you MUST close this MSYS2 window"
   warning "(use Alt-F4 or red [ X ], etc.), rather than 'exit'!!!"
-  read -p "Press [Enter] key when ready to start update..."
+  test -z "${noconfirm}" && read -p 'Press [Enter] key when ready to start update...'
   export PS1='Please close this window.'
   export PROMPT_COMMAND=
   msg "Updating core packages..."
@@ -102,10 +111,11 @@ else
     error "$(gettext "'%s' failed to update core packages.")" "$PACMAN"
     exit 1 # TODO: error code
   fi
-  while :
-  do
-    read -p  "Please close this window."
-  done
+  printf 'Please close this window.'
+  test -n "${noconfirm}" && exit 0
+  while true; do
+    read -s
+   done
 fi
 
 # vim: set noet:

--- a/scripts/update-core.sh.in
+++ b/scripts/update-core.sh.in
@@ -36,7 +36,9 @@ m4_include(library/utils_fixed_path.sh)
 usage() {
   local cmd="${0##*/}"
   printf "${cmd} (pacman) ${myver}\n\n"
-  printf 'usage: update-core [--noconfirm]\n\n'
+  printf 'usage: update-core [options]\n
+  --noconfirm  Do not ask for any confirmation
+  --norefresh  Do not refresh databases\n\n'
 }
 
 version() {
@@ -48,10 +50,15 @@ This is free software; see the source for copying conditions.\n\
 There is NO WARRANTY, to the extent permitted by law.\n")"
 }
 
+# pacman-like status functions
+msg()     { echo -e "${color_blue}::${color_white}" "${@}...${color_normal}"; }
+warning() { echo -e "${color_yellow}warning:${color_normal}" "${@}"; }
+error()   { echo -e "${color_red}error:${color_normal}" "${@}"; }
+
 
 run_pacman() {
 	local cmd
-	cmd=("$PACMAN_PATH" "$@")
+	cmd=("$PACMAN_PATH" --color auto "$@")
 
 	"${cmd[@]}"
 }
@@ -80,39 +87,49 @@ PACMAN=${PACMAN:-pacman}
 # save full path to command as PATH may change when sourcing /etc/profile
 PACMAN_PATH=$(type -P $PACMAN)
 
-# non-interactive usage
+# options
 for argument in "${@}"; do
-  if [[ "${argument}" = --noconfirm ]]; then
-    noconfirm='yes'
-    break
-  fi
+  case "${argument}" in
+    --noconfirm) noconfirm='yes' ;;
+    --norefresh) norefresh='yes' ;;
+  esac
 done
 
-msg "Update package databases..."
-if ! run_pacman -Sy; then
-  error "$(gettext "'%s' failed to update package databases.")" "$PACMAN"
-  exit 1 # TODO: error code
+# colors
+if [[ -t 1 && -z "${nocolor}" ]]; then
+  color_red='\e[1;31m'
+  color_yellow='\e[1;33m'
+  color_blue='\e[1;34m'
+  color_white='\e[1;37m'
+  color_normal='\e[0m'
 fi
 
-msg "Checking if there are critical packages to upgrade."
-if ! run_pacman -Qu ${CRITICAL_PACKAGES}; then
-  msg "No updates for core packages."
+if [[ -z "${norefresh}" ]]; then
+  if ! run_pacman -Sy; then
+    error "$(gettext "'%s' failed to update package databases.")" "$PACMAN"
+    exit 1 # TODO: error code
+  fi
+fi
+
+msg 'Starting core system upgrade'
+if ! run_pacman --color never -Qu ${CRITICAL_PACKAGES}; then
+  echo ' there is nothing to do'
 else
-  msg "Core packages require updating."
-  msg "Please close all other MSYS2 derived windows (e.g. terminal"
-  msg "windows, Bash sessions, etc) before proceeding."
-  warning "When the update has completed, you MUST close this MSYS2 window"
-  warning "(use Alt-F4 or red [ X ], etc.), rather than 'exit'!!!"
-  test -z "${noconfirm}" && read -p 'Press [Enter] key when ready to start update...'
-  export PS1='Please close this window.'
+  if [[ -z "${noconfirm}" ]]; then
+    warning 'please terminate all other MSYS2 programs and press ENTER to continue...'
+    read -s
+  fi
+
   export PROMPT_COMMAND=
-  msg "Updating core packages..."
+  export PS1='please exit MSYS2 immediately'
   if ! run_pacman -S --noconfirm --needed ${CRITICAL_PACKAGES} ${OPTIONAL_PACKAGES}; then
     error "$(gettext "'%s' failed to update core packages.")" "$PACMAN"
     exit 1 # TODO: error code
   fi
-  printf 'Please close this window.'
+
   test -n "${noconfirm}" && exit 0
+  warning 'please exit MSYS2 immediately without returning to shell'
+  warning 'for example close this window instead of calling exit'
   while true; do
     read -s
    done


### PR DESCRIPTION
This should make MSYS2 update fully scriptable, for example with batch files. Output has also been simplified and looks more like pacman.

![c92552e6-dcc3-11e5-8bfc-cd255956db80](https://cloud.githubusercontent.com/assets/1465469/13367960/5a9eb540-dcc5-11e5-9586-62a9473de3fb.png)