### PR TITLE
Adjustment for core update

### DIFF
--- a/lib/libalpm/alpm.h
+++ b/lib/libalpm/alpm.h
@@ -1540,6 +1540,12 @@ int alpm_trans_release(alpm_handle_t *handle);
 int alpm_sync_sysupgrade(alpm_handle_t *handle, int enable_downgrade);
 #ifdef __MSYS__
 int alpm_sync_sysupgrade_core(alpm_handle_t *handle, int enable_downgrade);
+
+/** Informs whether a package is a core package.
+ * @param pkg the package to check
+ * @return non-zero if this is a core package, zero otherwise
+ */
+int alpm_pkg_is_core_package(const alpm_pkg_t *pkg);
 #endif
 
 /** Add a package to the transaction.

--- a/lib/libalpm/package.c
+++ b/lib/libalpm/package.c
@@ -788,4 +788,20 @@ int SYMEXPORT alpm_pkg_should_ignore(alpm_handle_t *handle, alpm_pkg_t *pkg)
 	return 0;
 }
 
+#ifdef __MSYS__
+int SYMEXPORT alpm_pkg_is_core_package(const alpm_pkg_t *pkg)
+{
+	if (pkg == NULL)
+		return 0;
+	return
+		strcmp(pkg->name, "bash")                == 0 ||
+		strcmp(pkg->name, "filesystem")          == 0 ||
+		strcmp(pkg->name, "mintty")              == 0 ||
+		strcmp(pkg->name, "msys2-runtime")       == 0 ||
+		strcmp(pkg->name, "msys2-runtime-devel") == 0 ||
+		strcmp(pkg->name, "pacman")              == 0 ||
+		strcmp(pkg->name, "pacman-mirrors")      == 0;
+}
+#endif
+
 /* vim: set noet: */

--- a/lib/libalpm/sync.c
+++ b/lib/libalpm/sync.c
@@ -220,14 +220,7 @@ int SYMEXPORT alpm_sync_sysupgrade(alpm_handle_t *handle, int enable_downgrade)
 		alpm_pkg_t *lpkg = i->data;
 
 #ifdef __MSYS__
-		if(core_update
-			&& strcmp(lpkg->name, "bash")                != 0
-			&& strcmp(lpkg->name, "filesystem")          != 0
-			&& strcmp(lpkg->name, "mintty")              != 0
-			&& strcmp(lpkg->name, "msys2-runtime")       != 0
-			&& strcmp(lpkg->name, "msys2-runtime-devel") != 0
-			&& strcmp(lpkg->name, "pacman")              != 0
-			&& strcmp(lpkg->name, "pacman-mirrors")      != 0) {
+		if(core_update && !alpm_pkg_is_core_package(lpkg)) {
 			continue;
 		}
 #endif

--- a/lib/libalpm/sync.c
+++ b/lib/libalpm/sync.c
@@ -220,7 +220,8 @@ int SYMEXPORT alpm_sync_sysupgrade(alpm_handle_t *handle, int enable_downgrade)
 		alpm_pkg_t *lpkg = i->data;
 
 #ifdef __MSYS__
-		if(core_update && !alpm_pkg_is_core_package(lpkg)) {
+		/* Skip regular packages in core update, and core packages in regular update */
+		if(core_update != alpm_pkg_is_core_package(lpkg)) {
 			continue;
 		}
 #endif


### PR DESCRIPTION
Regular packages possibly specified as arguments along with --sysupgrade should now be ignored by core update, and core packages should now be skipped in regular update. In this example we can see that ruby is now installed as regular update, and that the filesystem warning is not anymore duplicated:

```patch
 $ pacman --sync --sysupgrade
 :: Starting core system upgrade...
 warning: filesystem: local (2016.05-2) is newer than msys (2016.05-1)
+warning: pacman: local (5.0.1.6419.75120af-1) is newer than msys (5.0.1.6403.520736d-1)
  there is nothing to do
 :: Starting full system upgrade...
-warning: filesystem: local (2016.05-2) is newer than msys (2016.05-1)
  there is nothing to do

 $ pacman --sync --sysupgrade ruby
 warning: ruby-2.3.0-2 is up to date -- reinstalling
 :: Starting core system upgrade...
 warning: filesystem: local (2016.05-2) is newer than msys (2016.05-1)
-warning: terminate other MSYS2 programs before proceeding
+warning: pacman: local (5.0.1.6419.75120af-1) is newer than msys (5.0.1.6403.520736d-1)
+ there is nothing to do
+:: Starting full system upgrade...
 resolving dependencies...
 looking for conflicting packages...

 Packages (1) ruby-2.3.0-2

 Total Installed Size:  19.80 MiB
 Net Upgrade Size:       0.00 MiB

 :: Proceed with installation? [Y/n] no
```